### PR TITLE
Support manifest version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@ import adapter from 'sveltekit-adapter-browser-extension';
 
 export default {
 	kit: {
-		adapter: adapter(),
+		adapter: adapter({
+			// default options are shown
+			pages: 'build', // the output directory for the pages of your extension
+			assets: undefined, // the asset output directory is derived from pages if not specified explicitly
+			fallback: undefined, // set to true to output an SPA-like extension
+			manifestVersion: 3 // the version of the automatically generated manifest (Version 3 is required by Chrome).
+		}),
 		appDir: 'ext', // This is important - chrome extensions can't handle the default _app directory name.
 		prerender: {
 			default: true

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 ## Usage
 
-Install with `npm i -D sveltekit-adapter-browser-extension`, then add the adapter to your `svelte.config.js`, and set the appDir to something without an underscore:
+Install with `npm i -D sveltekit-adapter-browser-extension`, then add the adapter to your `svelte.config.js`.
+
+Some additional configuration is required for this adapter to work - you need to (1) set ``appDir`` to something without an underscore and (2) tell kit to prerender its pages by default:
 
 ```js
 // svelte.config.js
@@ -13,7 +15,10 @@ import adapter from 'sveltekit-adapter-browser-extension';
 export default {
 	kit: {
 		adapter: adapter(),
-		appDir: 'ext' // This is important - chrome extensions can't handle the default _app directory name.
+		appDir: 'ext', // This is important - chrome extensions can't handle the default _app directory name.
+		prerender: {
+			default: true
+		}
 	}
 };
 ```

--- a/adapter-browser-extension.mjs
+++ b/adapter-browser-extension.mjs
@@ -1,5 +1,6 @@
 import { join } from 'path'
 import { writeFileSync, readFileSync, existsSync } from 'fs'
+import glob from 'tiny-glob'
 import sjcl from 'sjcl'
 import cheerio from 'cheerio'
 import { applyToDefaults } from '@hapi/hoek'
@@ -58,6 +59,19 @@ function load_manifest () {
 	return {}
 }
 
+// Quick and dirty helper function to externalize scripts. Will become obsolete once kit provides a config option to do this ahead of time.
+function externalizeScript(html, assets) {
+	return html.replace(
+		/<script type="module" data-hydrate="([\s\S]+)">([\s\S]+)<\/script>/,
+		(match, hydrationTarget, content) => {
+			const hash = Buffer.from(hash_script(content), 'base64').toString('hex');
+	         	const externalized_script_path = join(assets, `${hash}.js`);
+			writeFileSync(externalized_script_path, content);
+			return `<script type="module" data-hydrate="${hydrationTarget}" src="${hash}.js"></script>`;
+		}
+	);
+}
+
 
 /** @type {import('.')} */
 export default function ({ pages = 'build', assets = pages, fallback, manifestVersion = 3 } = {}) {
@@ -84,6 +98,18 @@ export default function ({ pages = 'build', assets = pages, fallback, manifestVe
 
 			const index_page = join(assets, 'index.html')
 			const index = readFileSync(index_page)
+			
+			/** The content security policy of manifest_version 3 does not allow for inlined scripts.
+			Until kit implements a config option (#1776) to externalize scripts, the below code block should do 
+			for a quick and dirty externalization of the scripts' contents **/
+            		if (manifestVersion === 3) {
+                		const HTML_files = await glob('**/*.html', { cwd: pages, dot: true, absolute: true, filesOnly: true })  
+                		HTML_files.forEach(path => {
+                    			let html = readFileSync(path, {encoding:'utf8'})
+ 					html = externalizeScript(html, assets)
+        				writeFileSync(path, html)
+            			});
+            		}
 
 			const generated_manifest = generate_manifest(index.toString(), manifestVersion)
 			const merged_manifest = applyToDefaults(generated_manifest, provided_manifest, { nullOverride: true })

--- a/adapter-browser-extension.mjs
+++ b/adapter-browser-extension.mjs
@@ -44,7 +44,7 @@ function generate_manifest (html, manifest_version) {
 			default_popup: 'index.html'
 		},
 		content_security_policy: {
-			"extension_pages": generate_csp(html)
+			"extension_pages": "script-src 'self'; object-src 'self'"
 		},
 		...project_placeholders
 	}


### PR DESCRIPTION
Closes #10.
I wanted to make this PR for a loooong time, but life got in the way. Sorry about that.
All changes should be pretty straight forward, except for maybe the hacky function to externalize scripts, which is necessary since Manifest Version 3 only allows externalized scripts in its content security policy.